### PR TITLE
improve error message for invalid lon/lat

### DIFF
--- a/DataGeneration/MapLocation.py
+++ b/DataGeneration/MapLocation.py
@@ -1,9 +1,9 @@
 class MapLocation:
     def __init__(self, latitude=0, longitude=0, id=0):
         if latitude > 90 or latitude < -90:
-            raise ValueError("latitude must be between -90 and 90")
+            raise ValueError("Error: latitude must be between -90 & 90. Latitude is %f" % float(latitude))
         if longitude > 180 or longitude < -180:
-            raise ValueError("longitude must be between -180 and 180")
+            raise ValueError("Error: longitude must be between -180 & 180. Longitude is %f" % float(longitude))
         self.latitude = latitude
         self.longitude = longitude
         self.id = id


### PR DESCRIPTION
This was a part of jeffrey Cochran's PR (but there were other changes in it, so I couldn't cherry pick it). 

I improved this as well; gives user that the latitude or longitude is outside the accepted values and returns those values too. 
ref https://github.com/opencleveland/RTAHeatMap/pull/16
